### PR TITLE
immich: migrate stack to v3 (VectorChord)

### DIFF
--- a/apps/immich/example.env
+++ b/apps/immich/example.env
@@ -4,7 +4,7 @@ HOST_POSTGRES_DATA=/cluster/immich/postgres
 HOST_CACHE_DATA=/cluster/immich/cache
 
 # Image tags
-IMMICH_VERSION=release
+IMMICH_VERSION=v3
 
 # Proxy configuration
 ENTRYPOINT=

--- a/apps/immich/immich.yml
+++ b/apps/immich/immich.yml
@@ -66,35 +66,19 @@ services:
 
   database:
     <<: *default-opts
-    image: docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:739cdd626151ff1f796dc95a6591b55a714f341c737e27f045019ceabf8e8c52
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
     environment:
       POSTGRES_PASSWORD_FILE: /run/secrets/immich_db_password
       POSTGRES_USER: ${DB_USERNAME:-postgres}
       POSTGRES_DB: ${DB_DATABASE_NAME:-immich}
       POSTGRES_INITDB_ARGS: '--data-checksums'
+      # Uncomment if database is on HDD (not SSD): DB_STORAGE_TYPE: 'HDD'
     volumes:
       - postgres_data:/var/lib/postgresql/data
     secrets:
       - source: immich_db_password
         target: immich_db_password
-    healthcheck:
-      test: >-
-        pg_isready --dbname="$${POSTGRES_DB}" --username="$${POSTGRES_USER}" || exit 1;
-        Chksum="$$(psql --dbname="$${POSTGRES_DB}" --username="$${POSTGRES_USER}" --tuples-only --no-align
-        --command='SELECT COALESCE(SUM(checksum_failures), 0) FROM pg_stat_database')";
-        echo "checksum failure count is $$Chksum";
-        [ "$$Chksum" = '0' ] || exit 1
-      interval: 5m
-      start_interval: 30s
-      start_period: 5m
-    command: >-
-      postgres
-      -c shared_preload_libraries=vectors.so
-      -c 'search_path="$$user", public, vectors'
-      -c logging_collector=on
-      -c max_wal_size=2GB
-      -c shared_buffers=512MB
-      -c wal_compression=on
+    shm_size: 128mb
     networks:
       - immich_network
     deploy:

--- a/apps/immich/immich.yml
+++ b/apps/immich/immich.yml
@@ -78,7 +78,6 @@ services:
     secrets:
       - source: immich_db_password
         target: immich_db_password
-    shm_size: 128mb
     networks:
       - immich_network
     deploy:


### PR DESCRIPTION
## Summary
Migrates Immich stack from v2 (pgvecto.rs) to v3 (VectorChord).

## Changes
- **example.env**: Update `IMMICH_VERSION=release` → `v3`
- **immich.yml**: Migrate database service:
  - New image: `ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0` (includes pgvecto.rs for migration + VectorChord)
  - Remove deprecated `healthcheck` and `command` (built into image)
  - Add commented `DB_STORAGE_TYPE: 'HDD'` for HDD configurations
  - Remove unsupported `shm_size` (Docker Swarm doesn't support it)

## Migration Process (tested on Raspberry Pi cluster)
1. Backup database and uploads
2. Update `.env` to `IMMICH_VERSION=v3`
3. Deploy stack - migration runs automatically on first v3 startup:
   - Creates VectorChord extension
   - Reindexes clip_index and face_index (takes minutes on Pi)
   - Drops pgvecto.rs extension
4. Verify v3.1.0 running with ML service healthy

## Notes
- ARM64 compatible (VectorChord 0.2+ supports ARM)
- SSD storage detected correctly (`Using SSD storage`)
- Optional: Switch to leaner `ghcr.io/immich-app/postgres:14-vectorchord0.4.3` after confirming backups work